### PR TITLE
Automatically generate symlinks for fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dependency-reduced-pom.xml
 
 target/
 .idea/
+
+.DS_Store
+**/.DS_Store

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+rm -rf target && mvn compile && mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>studio.dreamys</groupId>
     <artifactId>prometheus</artifactId>
-    <version>essential-1.0.0</version>
+    <version>1.1.0-essential</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>studio.dreamys</groupId>
     <artifactId>prometheus</artifactId>
-    <version>1.1.0-essential</version>
+    <version>1.1.1-essential</version>
 
     <repositories>
         <repository>
@@ -71,6 +71,11 @@
             <groupId>net.fabricmc</groupId>
             <artifactId>fabric-loader</artifactId>
             <version>0.16.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.24.3</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,11 @@
             <id>spongepowered-repo</id>
             <url>https://repo.spongepowered.org/maven/</url>
         </repository>
+        <repository>
+            <id>fabric</id>
+            <url>https://maven.fabricmc.net</url>
+        </repository>
     </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.spongepowered</groupId>
@@ -63,6 +66,11 @@
             <version>1.3.5.5</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/essential.mock.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>net.fabricmc</groupId>
+            <artifactId>fabric-loader</artifactId>
+            <version>0.16.9</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/studio/dreamys/prometheus/Prometheus.java
+++ b/src/main/java/studio/dreamys/prometheus/Prometheus.java
@@ -1,0 +1,40 @@
+package studio.dreamys.prometheus;
+
+import net.fabricmc.api.ClientModInitializer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.Mixins;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class Prometheus implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        System.out.println("Test from prometheus");
+        try {
+            chainLoadMixins();
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+
+        }
+    }
+    private void chainLoadMixins() throws ReflectiveOperationException {
+        if (Mixins.getUnvisitedCount() == 0) {
+            return; // nothing to do, Mixin already loaded our config by itself
+        }
+
+        MixinEnvironment environment = MixinEnvironment.getDefaultEnvironment();
+        Object transformer = environment.getActiveTransformer();
+        Field processorField = transformer.getClass().getDeclaredField("processor");
+        processorField.setAccessible(true);
+        Object processor = processorField.get(transformer);
+        Method select = processor.getClass().getDeclaredMethod("select", MixinEnvironment.class);
+        select.setAccessible(true);
+        select.invoke(processor, environment);
+    }
+}

--- a/src/main/java/studio/dreamys/prometheus/Prometheus.java
+++ b/src/main/java/studio/dreamys/prometheus/Prometheus.java
@@ -2,37 +2,29 @@ package studio.dreamys.prometheus;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.MixinEnvironment;
-import org.spongepowered.asm.mixin.Mixins;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Prometheus implements ClientModInitializer {
+    private static final Logger LOGGER = LogManager.getLogger(Prometheus.class);
     FilenameFilter isJar = (dir, name) -> name.endsWith(".jar");
     @Override
     public void onInitializeClient() {
-        System.out.println("Test from prometheus");
+        LOGGER.debug("Prometheus is initializing");
         if (!FabricLoader.getInstance().isModLoaded("essential-container") && FabricLoader.getInstance().isModLoaded("essential")) {
-            System.out.println("Essential is already loaded");
+            LOGGER.warn("Essential is already loaded, skipping symlink creation");
             return;
         }
         File modsDir = new File("mods");
         assert modsDir.exists();
         Path essentialDir = modsDir.toPath().toAbsolutePath().getParent().resolve("essential");
-        System.out.println("Essential Directory: " + essentialDir.toAbsolutePath());
+        LOGGER.debug("Essential Directory: {}", essentialDir.toAbsolutePath());
         Path symlinkJarPath = modsDir.toPath();
         // Create symlink
         if (!essentialDir.toFile().exists()) {
@@ -42,11 +34,11 @@ public class Prometheus implements ClientModInitializer {
             try {
                 Path symlinkJar = symlinkJarPath.resolve(file.getName());
                 if (symlinkJar.toFile().exists()) {
-                    System.out.println("Symlink already exists: " + symlinkJar.toAbsolutePath());
+                    LOGGER.warn("Symlink already exists: {}", symlinkJar.toAbsolutePath());
                     break;
                 }
                 Files.createSymbolicLink(symlinkJar, file.toPath());
-                System.out.println("Created symlink: " + symlinkJar.toAbsolutePath());
+                LOGGER.info("Created symlink: {}", symlinkJar.toAbsolutePath());
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/studio/dreamys/prometheus/Prometheus.java
+++ b/src/main/java/studio/dreamys/prometheus/Prometheus.java
@@ -1,6 +1,7 @@
 package studio.dreamys.prometheus;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.Mixins;
@@ -9,32 +10,46 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
 
 public class Prometheus implements ClientModInitializer {
+    FilenameFilter isJar = (dir, name) -> name.endsWith(".jar");
     @Override
     public void onInitializeClient() {
         System.out.println("Test from prometheus");
-        try {
-            chainLoadMixins();
-        } catch (ReflectiveOperationException e) {
-            e.printStackTrace();
-
+        if (!FabricLoader.getInstance().isModLoaded("essential-container") && FabricLoader.getInstance().isModLoaded("essential")) {
+            System.out.println("Essential is already loaded");
+            return;
         }
-    }
-    private void chainLoadMixins() throws ReflectiveOperationException {
-        if (Mixins.getUnvisitedCount() == 0) {
-            return; // nothing to do, Mixin already loaded our config by itself
+        File modsDir = new File("mods");
+        assert modsDir.exists();
+        Path essentialDir = modsDir.toPath().toAbsolutePath().getParent().resolve("essential");
+        System.out.println("Essential Directory: " + essentialDir.toAbsolutePath());
+        Path symlinkJarPath = modsDir.toPath();
+        // Create symlink
+        if (!essentialDir.toFile().exists()) {
+            return; // Essential not found, let it create itself
         }
-
-        MixinEnvironment environment = MixinEnvironment.getDefaultEnvironment();
-        Object transformer = environment.getActiveTransformer();
-        Field processorField = transformer.getClass().getDeclaredField("processor");
-        processorField.setAccessible(true);
-        Object processor = processorField.get(transformer);
-        Method select = processor.getClass().getDeclaredMethod("select", MixinEnvironment.class);
-        select.setAccessible(true);
-        select.invoke(processor, environment);
+        for (File file : Objects.requireNonNull(essentialDir.toFile().listFiles(isJar))) {
+            try {
+                Path symlinkJar = symlinkJarPath.resolve(file.getName());
+                if (symlinkJar.toFile().exists()) {
+                    System.out.println("Symlink already exists: " + symlinkJar.toAbsolutePath());
+                    break;
+                }
+                Files.createSymbolicLink(symlinkJar, file.toPath());
+                System.out.println("Created symlink: " + symlinkJar.toAbsolutePath());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,9 +18,13 @@
     "mixins": [
         "prometheus.mixins.json"
     ],
+    "entrypoints": {
+        "client": ["studio.dreamys.prometheus.Prometheus"]
+    },
     "depends": {
         "minecraft": ">=1.16.5",
-        "java": ">=8"
+        "java": ">=8",
+        "essential-loader": "*"
     },
     "breaks": {
         "viafabricplus": "*",


### PR DESCRIPTION
Basically just symlink the `.minecraft/essential` jar -> `.minecraft/mods` automatically

tested and works on my mac, needs more testing on windows/linux

also a logger so that we don't have to `sout()`