### PR TITLE
Implement cosmetic dump feature + other small adjustments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 
+Copyright (c) 2025 
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -649,7 +649,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     essential
-    Copyright (C) 2024 dxxxxy
+    Copyright (C) 2025 prometheus reengineering
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -669,7 +669,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    essential Copyright (C) 2024 dxxxxy
+    essential Copyright (C) 2025 prometheus reengineering
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/LICENSE
+++ b/LICENSE
@@ -649,7 +649,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     essential
-    Copyright (C) 2025 prometheus reengineering
+    Copyright (C) 2025 Prometheus Reengineering
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -669,7 +669,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    essential Copyright (C) 2025 prometheus reengineering
+    essential Copyright (C) 2025 Prometheus Reengineering
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # essential
 The prometheus' patch for Essential Mod.
 
-![Compatibility: Infinite](https://img.shields.io/badge/COMPATIBILITY-∞-0?style=for-the-badge)
+![Compatibility: Infinite](https://img.shields.io/badge/COMPATIBILITY-=<1.12_>=1.18-0?style=for-the-badge)
 [![Download Count](https://img.shields.io/github/downloads/prometheusreengineering/essential/total?style=for-the-badge)](https://github.com/prometheusreengineering/essential/releases/)
 [![Discord](https://img.shields.io/discord/1197794960985043034?style=for-the-badge&label=Discord&color=rgb(88%2C%20101%2C%20242)%20)](https://discord.gg/BFDWmPfmXg)
 
 ## Features
 - Unlocks ALL cosmetics and emotes.
 - Lightweight and non-invasive.
-- Compatible with all versions of Essential Mod.
+- Dumps cosmetics into minecraft logs.
+- Compatible with *almost* all versions of Essential Mod.
 
 ### Known Issues
 - Patch does not apply on Fabric against the Essential Mod loader.
-
-### Future Plans
-- Cosmetic dumps.
 
 ## Disclaimer
 This project is intended for educational purposes only. We are not responsible for any damage caused by this project.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>studio.dreamys</groupId>
     <artifactId>prometheus</artifactId>
-    <version>essential-1.0.0</version>
+    <version>1.1.0-essential</version>
 
     <repositories>
         <repository>

--- a/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/cosmetics/MixinCosmeticsManager.java
+++ b/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/cosmetics/MixinCosmeticsManager.java
@@ -1,4 +1,4 @@
-package studio.dreamys.prometheus.mixin.gg.essential.network.connectionmanager;
+package studio.dreamys.prometheus.mixin.gg.essential.network.connectionmanager.cosmetics;
 
 import gg.essential.event.client.ClientTickEvent;
 import gg.essential.network.connectionmanager.cosmetics.CosmeticsManager;

--- a/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/handler/cosmetics/MixinServerCosmeticsPopulatePacketHandler.java
+++ b/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/handler/cosmetics/MixinServerCosmeticsPopulatePacketHandler.java
@@ -1,0 +1,29 @@
+package studio.dreamys.prometheus.mixin.gg.essential.network.connectionmanager.handler.cosmetics;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import gg.essential.connectionmanager.common.packet.cosmetic.ServerCosmeticsPopulatePacket;
+import gg.essential.cosmetics.model.Cosmetic;
+import gg.essential.network.connectionmanager.ConnectionManager;
+import gg.essential.network.connectionmanager.cosmetics.CosmeticsManager;
+import gg.essential.network.connectionmanager.handler.cosmetics.ServerCosmeticsPopulatePacketHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Iterator;
+
+@Mixin(value = ServerCosmeticsPopulatePacketHandler.class, remap = false)
+public class MixinServerCosmeticsPopulatePacketHandler {
+    @Unique
+    private static final Gson essential$gson = new GsonBuilder().setPrettyPrinting().create();
+
+    @SuppressWarnings("rawtypes")
+    @Inject(method = "onHandle(Lgg/essential/network/connectionmanager/ConnectionManager;Lgg/essential/connectionmanager/common/packet/cosmetic/ServerCosmeticsPopulatePacket;)V", at = @At(value = "INVOKE", target = "Lgg/essential/cosmetics/model/Cosmetic;getType()Ljava/lang/String;"), locals = LocalCapture.CAPTURE_FAILSOFT)
+    public void onHandle(ConnectionManager connectionManager, ServerCosmeticsPopulatePacket packet, CallbackInfo ci, CosmeticsManager cosmeticsManager, Iterator var4, Cosmetic cosmetic) {
+        System.out.println(essential$gson.toJson(cosmetic));
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,24 +1,24 @@
-modLoader="lowcodefml"
-loaderVersion="[36,)"
-license="GPL-3.0"
+modLoader = "lowcodefml"
+loaderVersion = "[25,)"
+license = "GPL-3.0"
 
 [[mods]]
-modId="prometheus"
-version="0.0.0" # not to be updated since the forge folks like to enforce strict versioning </3
-displayName="Prometheus"
+modId = "prometheus"
+version = "0.0.0" # not to be updated since the forge folks like to enforce strict versioning </3
+displayName = "Prometheus"
 description = "The prometheus' patch for Essential Mod."
 logoFile = "assets/prometheus/icon.png"
 features = { java_version = "[8,)" }
 authors = ["dxxxxy"]
 
 [[dependencies.prometheus]]
-modId="forge"
-mandatory=true
-versionRange="[36,)"
+modId = "forge"
+mandatory = true
+versionRange = "[25,)"
 side = "CLIENT"
 
 [[dependencies.prometheus]]
-modId="minecraft"
-mandatory=true
-versionRange="[1.16.5,)"
+modId = "minecraft"
+mandatory = true
+versionRange = "[1.13,)"
 side = "CLIENT"

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,8 +1,12 @@
-[{
-  "modid": "prometheus",
-  "name": "Prometheus",
-  "description": "The prometheus' patch for Essential Mod.",
-  "version": "${project.version}",
-  "authorList": ["dxxxxy"],
-  "logoFile": "assets/prometheus/icon.png"
-}]
+[
+    {
+        "modid": "prometheus",
+        "name": "Prometheus",
+        "description": "The prometheus' patch for Essential Mod.",
+        "version": "${project.version}",
+        "authorList": [
+            "dxxxxy"
+        ],
+        "logoFile": "assets/prometheus/icon.png"
+    }
+]

--- a/src/main/resources/prometheus.mixins.json
+++ b/src/main/resources/prometheus.mixins.json
@@ -1,11 +1,12 @@
 {
-	"required": true,
-	"package": "studio.dreamys.prometheus.mixin",
-	"compatibilityLevel": "JAVA_8",
-	"mixins": [
-		"gg.essential.network.connectionmanager.MixinCosmeticsManager"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	}
+    "required": true,
+    "package": "studio.dreamys.prometheus.mixin",
+    "compatibilityLevel": "JAVA_8",
+    "mixins": [
+        "gg.essential.network.connectionmanager.cosmetics.MixinCosmeticsManager",
+        "gg.essential.network.connectionmanager.handler.cosmetics.MixinServerCosmeticsPopulatePacketHandler"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
 }


### PR DESCRIPTION
This pull request includes several changes across multiple files, primarily focused on updating licensing information, modifying compatibility details, and restructuring the cosmetics management code. The most important changes are highlighted below:

### Licensing Updates:
* Updated the copyright year from 2024 to 2025 in the `LICENSE` file.
* Changed the author name in the `LICENSE` file to "prometheus reengineering". [[1]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L652-R652) [[2]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L672-R672)

### Compatibility and Version Updates:
* Updated the compatibility badge in `README.md` to reflect support for versions `<1.12_>1.18`.
* Changed the project version in `pom.xml` from `essential-1.0.0` to `1.1.0-essential`.
* Adjusted the `loaderVersion` and `versionRange` in `src/main/resources/META-INF/mods.toml` to support older versions. [[1]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L2-R2) [[2]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L17-R23)

### Code Restructuring:
* Renamed and moved `MixinCosmeticsManager.java` to a new package path.
* Added a new mixin class `MixinServerCosmeticsPopulatePacketHandler.java` for handling cosmetic packet population.
* Updated `prometheus.mixins.json` to include the new mixin classes.

### Miscellaneous:
* Reformatted `mcmod.info` for better readability.