### PR TITLE
Fix 1.3.5.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# BROKEN AS OF MAY 9th 2025
-### Either downgrade to essential v1.3.5.11 or wait for a fix.
-
 # essential
 The prometheus' patch for Essential Mod.
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>gg.essential</groupId>
             <artifactId>essential</artifactId>
-            <version>1.3.5.5</version>
+            <version>1.3.6.1</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/essential.mock.jar</systemPath>
         </dependency>

--- a/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/cosmetics/MixinCosmeticsManager.java
+++ b/src/main/java/studio/dreamys/prometheus/mixin/gg/essential/network/connectionmanager/cosmetics/MixinCosmeticsManager.java
@@ -13,7 +13,7 @@ public abstract class MixinCosmeticsManager {
     @Shadow
     public abstract void unlockAllCosmetics();
 
-    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;complete(Ljava/lang/Object;)Z", shift = At.Shift.AFTER))
+    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lgg/essential/gui/elementa/state/v2/MutableState;set(Ljava/lang/Object;)V", shift = At.Shift.AFTER))
     public void onTick(ClientTickEvent tickEvent, CallbackInfo ci) {
         unlockAllCosmetics();
     }


### PR DESCRIPTION
This pull request includes updates to the documentation, dependency versioning, and a method injection point in the codebase. The most important changes include removing outdated information from the `README.md`, upgrading the `essential` dependency version in `pom.xml`, and modifying the injection point in the `onTick` method of `MixinCosmeticsManager`.

### Documentation Updates:
* Removed outdated information about the Essential Mod being broken as of May 9th, 2025, from the `README.md`. This cleanup ensures the documentation reflects the current state of the project.

### Dependency Updates:
* Upgraded the `essential` dependency from version `1.3.5.5` to `1.3.6.1` in `pom.xml`. This update likely includes bug fixes or new features provided by the newer version.

### Code Updates:
* Updated the injection point in the `onTick` method of `MixinCosmeticsManager` to target `MutableState.set` instead of `CompletableFuture.complete`. This change may address a functional or compatibility issue with the method's behavior.